### PR TITLE
feat: add smove package command skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -151,7 +151,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/eigerco/bcs.git?branch=master#850598d0cb128f10ecf4ce87ff94281ee46e6524"
 dependencies = [
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/eigerco/bcs.git#850598d0cb128f10ecf4ce87ff94281ee46e6524"
 dependencies = [
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
- "serde 1.0.189",
+ "serde 1.0.190",
  "thiserror",
 ]
 
@@ -256,7 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
 dependencies = [
  "memchr",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -274,7 +274,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -398,7 +398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.189",
+ "serde 1.0.190",
  "termcolor",
  "unicode-width",
 ]
@@ -442,7 +442,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom",
  "rust-ini",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -687,7 +687,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "serde 1.0.189",
+ "serde 1.0.190",
  "signature",
 ]
 
@@ -700,7 +700,7 @@ dependencies = [
  "curve25519-dalek-fiat",
  "ed25519",
  "rand",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -991,7 +991,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
 ]
 
 [[package]]
@@ -1000,7 +1000,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
- "ahash 0.8.5",
+ "ahash 0.8.6",
 ]
 
 [[package]]
@@ -1238,7 +1238,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab388864246d58a276e60e7569a833d9cc4cd75c66e5ca77c177dad38e59996"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
  "dashmap",
  "hashbrown 0.12.3",
  "once_cell",
@@ -1360,7 +1360,7 @@ version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1440,31 +1440,31 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "hashbrown 0.14.2",
  "move-core-types",
  "ref-cast",
- "serde 1.0.189",
+ "serde 1.0.190",
  "variant_count",
 ]
 
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1473,13 +1473,13 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -1491,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "fail",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "clap",
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1557,7 +1557,7 @@ dependencies = [
  "read-write-set",
  "read-write-set-dynamic",
  "reqwest",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "difference",
@@ -1577,7 +1577,7 @@ dependencies = [
  "move-core-types",
  "num-bigint",
  "once_cell",
- "serde 1.0.189",
+ "serde 1.0.190",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1614,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
@@ -1625,7 +1625,7 @@ dependencies = [
  "primitive-types",
  "rand",
  "ref-cast",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde_bytes",
  "uint",
 ]
@@ -1633,7 +1633,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1647,13 +1647,13 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "clap",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "codespan",
@@ -1683,13 +1683,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1697,13 +1697,13 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "hex",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "hex",
@@ -1743,13 +1743,13 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "codespan",
@@ -1769,13 +1769,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1799,7 +1799,7 @@ dependencies = [
  "ptree",
  "regex",
  "reqwest",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde_yaml",
  "sha2 0.9.9",
  "tempfile",
@@ -1811,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1838,7 +1838,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde_json",
  "simplelog",
  "tokio",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1868,7 +1868,7 @@ dependencies = [
  "pretty",
  "rand",
  "regex",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde_json",
  "tera",
  "tokio",
@@ -1877,18 +1877,18 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1897,13 +1897,13 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1924,13 +1924,13 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -1942,13 +1942,13 @@ dependencies = [
  "move-model",
  "move-stackless-bytecode",
  "num",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "hex",
  "log",
@@ -1969,16 +1969,16 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "once_cell",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "better_any",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "better_any",
  "fail",
@@ -2043,25 +2043,25 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
  "once_cell",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.189",
+ "serde 1.0.190",
  "smallvec",
 ]
 
@@ -2326,7 +2326,7 @@ dependencies = [
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -2412,9 +2412,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
+checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2423,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
+checksum = "81d78524685f5ef2a3b3bd1cafbc9fcabb036253d9b1463e726a91cd16e2dfc2"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2433,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
+checksum = "68bd1206e71118b5356dae5ddc61c8b11e28b09ef6a31acbd15ea48a28e0c227"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2446,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
+checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
 dependencies = [
  "once_cell",
  "pest",
@@ -2622,7 +2622,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde-value",
  "tint",
 ]
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -2719,7 +2719,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#4721adee5839213eb4158528f4ffbbcabb32b4c5"
+source = "git+https://github.com/eigerco/substrate-move.git#8cfd40df76bd9a611fb08e14043318cde9a0ae8b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -2839,7 +2839,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
@@ -2945,9 +2945,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
@@ -2971,7 +2971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
- "serde 1.0.189",
+ "serde 1.0.190",
  "thiserror",
 ]
 
@@ -2982,7 +2982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -2991,14 +2991,14 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3013,7 +3013,7 @@ checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -3025,7 +3025,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -3036,7 +3036,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap 1.9.3",
  "ryu",
- "serde 1.0.189",
+ "serde 1.0.190",
  "yaml-rust",
 ]
 
@@ -3182,7 +3182,9 @@ dependencies = [
  "clap",
  "move-cli",
  "move-core-types",
+ "move-package",
  "move-stdlib",
+ "move-vm-runtime",
  "move-vm-test-utils",
 ]
 
@@ -3308,7 +3310,7 @@ dependencies = [
  "pest_derive",
  "rand",
  "regex",
- "serde 1.0.189",
+ "serde 1.0.190",
  "serde_json",
  "slug",
  "unic-segment",
@@ -3425,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3443,7 +3445,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -3461,7 +3463,7 @@ dependencies = [
  "combine",
  "indexmap 1.9.3",
  "itertools",
- "serde 1.0.189",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -3927,18 +3929,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.11"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c19fae0c8a9efc6a8281f2e623db8af1db9e57852e04cde3e754dd2dc29340f"
+checksum = "81ba595b9f2772fbee2312de30eeb80ec773b4cb2f1e8098db024afadda6c06f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.11"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc56589e9ddd1f1c28d4b4b5c773ce232910a6bb67a70133d61c9e347585efe9"
+checksum = "772666c41fb6dceaf520b564b962d738a8e1a83b41bd48945f50837aed78bb1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ move-stdlib = { git = "https://github.com/eigerco/substrate-move.git" }
 move-core-types = { git = "https://github.com/eigerco/substrate-move.git" }
 # TODO(eiger): remove eventually once the gas cost table is ready
 move-vm-test-utils = { git = "https://github.com/eigerco/substrate-move.git" }
+move-package = { git = "https://github.com/eigerco/substrate-move.git" }
+move-vm-runtime = { git = "https://github.com/eigerco/substrate-move.git" }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,0 +1,3 @@
+//! List of smove subcommands.
+
+pub(crate) mod package;

--- a/src/cmd/package.rs
+++ b/src/cmd/package.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use clap::Parser;
+
+use crate::run_context::RunContext;
+use crate::run_move_cli;
+
+/// Package command bundles modules into packages.
+#[derive(Parser, Debug)]
+#[clap(about = "smove package")]
+pub struct Package {}
+
+impl Package {
+    /// Executes the command.
+    pub fn run(&mut self, ctx: &RunContext) -> Result<()> {
+        // Build all move modules
+        run_move_cli::execute_build(ctx)?;
+
+        // TODO(Rqnsom): Impl module filtering and actual bundling
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,53 @@
+use crate::run_context::RunContext;
+use anyhow::Result;
+use clap::Parser;
+use move_cli::Move;
+use std::path::PathBuf;
+
+mod cmd;
+mod run_context;
+mod run_move_cli;
+
+/// CLI frontend for the Move compiler and VM in Substrate
+#[derive(Parser)]
+#[clap(name = "smove", author, about, long_about = None)]
+struct SmoveArgs {
+    /// Native move-cli arguments
+    #[clap(flatten)]
+    move_args: Move,
+
+    /// Commands
+    #[clap(subcommand)]
+    cmd: SmoveCommand,
+}
+
+/// Move CLI and smove subcommands
+#[derive(clap::Subcommand)]
+enum SmoveCommand {
+    /// Native move-cli commands
+    #[clap(flatten)]
+    MoveCommand(move_cli::Command),
+
+    /// Create package bundle
+    #[clap(about = "Create package bundle")]
+    Package {
+        #[clap(flatten)]
+        cmd: cmd::package::Package,
+    },
+
+    /// Run the script and create a transcation for the pallet
+    #[clap(about = "Run the script and create a transcation for the pallet")]
+    Run {},
+}
+
+/// Run the smove CLI
+pub fn smove_cli(cwd: PathBuf) -> Result<()> {
+    let SmoveArgs { move_args, cmd } = SmoveArgs::parse();
+    let ctx = RunContext::new(cwd, move_args)?;
+
+    match cmd {
+        SmoveCommand::MoveCommand(cmd) => run_move_cli::run_command(&ctx, cmd),
+        SmoveCommand::Package { mut cmd } => cmd.run(&ctx),
+        SmoveCommand::Run {} => unimplemented!(),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,50 +1,7 @@
-use clap::Parser;
-use move_cli::Move;
-use move_core_types::{errmap::ErrorMapping, language_storage::CORE_CODE_ADDRESS};
-use move_stdlib::natives::{all_natives, GasParameters};
-
-/// CLI frontend for the Move compiler and VM in Substrate
-#[derive(Parser)]
-#[clap(name = "smove", author, about, long_about = None)]
-pub struct SmoveArgs {
-    /// Native move-cli arguments
-    #[clap(flatten)]
-    pub move_args: Move,
-
-    /// Commands
-    #[clap(subcommand)]
-    pub cmd: SmoveCommand,
-}
-
-/// Move CLI and smove subcommands
-#[derive(clap::Subcommand)]
-pub enum SmoveCommand {
-    /// Native move-cli commands
-    #[clap(flatten)]
-    MoveCommand(move_cli::Command),
-
-    /// Create package bundle
-    #[clap(about = "Create package bundle")]
-    Package {},
-
-    /// Run the script and create a transcation for the pallet
-    #[clap(about = "Run the script and create a transcation for the pallet")]
-    Run {},
-}
+use smove::smove_cli;
 
 fn main() -> anyhow::Result<()> {
-    let SmoveArgs { move_args, cmd } = SmoveArgs::parse();
+    let cwd = std::env::current_dir()?;
 
-    let error_descriptions: ErrorMapping = bcs::from_bytes(move_stdlib::doc::error_descriptions())?;
-    // TODO(eiger): Use custom cost table
-    let cost_table = &move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE;
-    let natives = all_natives(CORE_CODE_ADDRESS, GasParameters::zeros());
-
-    match cmd {
-        SmoveCommand::MoveCommand(cmd) => {
-            move_cli::run_cli(natives, cost_table, &error_descriptions, move_args, cmd)
-        }
-        SmoveCommand::Package {} => unimplemented!(),
-        SmoveCommand::Run {} => unimplemented!(),
-    }
+    smove_cli(cwd)
 }

--- a/src/run_context.rs
+++ b/src/run_context.rs
@@ -1,0 +1,52 @@
+use anyhow::{anyhow, Result};
+use move_cli::Move as MoveCliArgs;
+use move_core_types::errmap::ErrorMapping;
+use move_core_types::language_storage::CORE_CODE_ADDRESS;
+use move_package::source_package::parsed_manifest::SourceManifest;
+use move_package::source_package::{layout, manifest_parser};
+use move_stdlib::natives::{all_natives, GasParameters};
+use move_vm_runtime::native_functions::NativeFunctionTable;
+use move_vm_test_utils::gas_schedule::CostTable;
+use std::fs::read_to_string;
+use std::path::PathBuf;
+
+/// Move compilation related data.
+pub struct RunContext {
+    /// Project directory.
+    pub project_root_dir: PathBuf,
+    /// `move_cli` arguments.
+    pub move_args: MoveCliArgs,
+    /// `Move.toml` contents.
+    pub manifest: SourceManifest,
+    /// Error descriptions.
+    pub error_descriptions: ErrorMapping,
+    /// Native functions.
+    pub natives: NativeFunctionTable,
+    /// Cost table.
+    pub cost_table: CostTable,
+}
+
+impl RunContext {
+    /// Create a new instance.
+    pub fn new(project_root_dir: PathBuf, move_args: MoveCliArgs) -> Result<Self> {
+        // TODO(eiger): Use a custom cost table
+        let cost_table = move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE.clone();
+        let natives = all_natives(CORE_CODE_ADDRESS, GasParameters::zeros());
+        let error_descriptions = bcs::from_bytes(move_stdlib::doc::error_descriptions())?;
+
+        let manifest_string =
+            read_to_string(project_root_dir.join(layout::SourcePackageLayout::Manifest.path()))
+                .map_err(|_| anyhow!("Move.toml not found. Path: {:?}", &project_root_dir))?;
+        let toml_manifest = manifest_parser::parse_move_manifest_string(manifest_string)?;
+        let manifest = manifest_parser::parse_source_manifest(toml_manifest)?;
+
+        Ok(Self {
+            project_root_dir,
+            move_args,
+            manifest,
+            error_descriptions,
+            natives,
+            cost_table,
+        })
+    }
+}

--- a/src/run_move_cli.rs
+++ b/src/run_move_cli.rs
@@ -1,0 +1,24 @@
+//! A handler module for move_cli.
+
+use crate::run_context::RunContext;
+use anyhow::Result;
+use move_cli::base::build::Build;
+use move_cli::Command;
+
+/// Execute `move_cli build`.
+pub fn execute_build(ctx: &RunContext) -> Result<()> {
+    let cmd = Command::Build(Build);
+
+    run_command(ctx, cmd)
+}
+
+/// Execute move_cli subcommand.
+pub fn run_command(ctx: &RunContext, command: Command) -> Result<()> {
+    move_cli::run_cli(
+        ctx.natives.clone(),
+        &ctx.cost_table,
+        &ctx.error_descriptions,
+        &ctx.move_args,
+        command,
+    )
+}


### PR DESCRIPTION
- refactor: simplify binary entry point
- feat: add `smove package` command
  - Command currently performs the same action as `smove build`. It shall be extended with bundling functionality.
- feat: add cli context handler
- feat: add move_cli handler

In the next PR, we'll extend this command with the full functionality.