### PR TITLE
feat: basic create-transaction command skeleton

### DIFF
--- a/src/cmd/bundle.rs
+++ b/src/cmd/bundle.rs
@@ -21,9 +21,9 @@ pub struct Bundle {
     #[clap(
         short,
         long,
-        help = "Bundle name. By default it is the same as the name of the pacakge."
+        help = "Bundle name. By default it is the same as the name of the package."
     )]
-    name: Option<String>,
+    name: Option<PathBuf>,
 
     // Modules are taken from the <PROJECT_PATH>/build/<PROJECT_NAME>/bytecode_modules directory.
     // The names are case-insensitive and can be specified with an extension.mv or without it.
@@ -63,10 +63,10 @@ impl Bundle {
 
         // Path to the output file
         let bundle_name = match self.name {
-            Some(ref name) => name,
-            _ => ctx.manifest()?.package.name.as_str(),
+            Some(ref name) => name.clone(),
+            _ => PathBuf::from(ctx.manifest()?.package.name.as_str()),
         };
-        let output_file_path = ctx.bundle_output_path(bundle_name)?;
+        let output_file_path = ctx.bundle_output_path(&bundle_name)?;
         if output_file_path.exists() {
             fs::remove_file(&output_file_path)?;
         }
@@ -75,10 +75,7 @@ impl Bundle {
 
         println!(
             "Modules are bundled under: {}",
-            output_file_path
-                .canonicalize()
-                .unwrap_or_default()
-                .display()
+            output_file_path.canonicalize()?.display()
         );
 
         Ok(())

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,3 +2,6 @@
 
 pub(super) mod bundle;
 pub(super) mod node;
+pub(super) mod script;
+
+mod script_transaction;

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -1,0 +1,62 @@
+use anyhow::{Error, Result};
+use clap::Parser;
+use move_binary_format::file_format::CompiledScript;
+use std::fs;
+use std::path::PathBuf;
+
+use super::script_transaction::ScriptTransaction;
+use crate::run_context::RunContext;
+
+/// Create a script transaction.
+#[derive(Parser, Debug)]
+#[clap(about = "smove create-transaction")]
+pub struct CreateTransaction {
+    #[clap(short, long, help = "Path for the compiled Move script.")]
+    compiled_script_path: PathBuf,
+    // TODO(rqnsom): add script parameters here.
+}
+
+impl CreateTransaction {
+    /// Executes the command.
+    pub fn execute(&mut self, ctx: &RunContext) -> Result<()> {
+        let compiled_script = &self.compiled_script_path;
+        let script_bc = fs::read(compiled_script)
+            .map_err(|e| Error::msg(format!("Can't read '{}':\n{e}", compiled_script.display())))?;
+
+        // Check the script bytecode and verify the parameter rules.
+        verify_script_integrity(&script_bc)?;
+
+        // TODO(Rqnsom): maybe use a function to create this:
+        let tx = ScriptTransaction {
+            bytecode: script_bc,
+            args: vec![],
+            type_args: vec![],
+        };
+
+        // Path to the output file.
+        let tx_name = compiled_script.file_name().unwrap(); // this can't fail in case fs::read succeds above.
+        let output_file_path = ctx.script_tx_output_path(&tx_name)?;
+        if output_file_path.exists() {
+            fs::remove_file(&output_file_path)?;
+        }
+        fs::write(&output_file_path, tx.encode()?)?;
+
+        println!(
+            "Script transaction is created at:\n{}",
+            output_file_path.canonicalize()?.display()
+        );
+
+        Ok(())
+    }
+}
+
+// Check script integrity and ensure the parameters are correct (signers should always come first).
+fn verify_script_integrity(bytecode: &[u8]) -> Result<()> {
+    let _compiled_script = CompiledScript::deserialize(bytecode)
+        .map_err(|e| Error::msg(format!("Cannot deserialize the Move script:\n{e}")))?;
+
+    // TODO(Rqnsom): verify signer rule in the parameter list after the same check is implemented
+    // in the substrate layer.
+
+    Ok(())
+}

--- a/src/cmd/script_transaction.rs
+++ b/src/cmd/script_transaction.rs
@@ -1,0 +1,34 @@
+//! IMPORTANT:
+//! Temporary location for the ScriptTransaction implementation during the development
+//! before we move it to the move-vm-backend-common crate.
+
+use anyhow::{Error, Result};
+use core::convert::TryFrom;
+use move_core_types::language_storage::TypeTag;
+use serde::{Deserialize, Serialize};
+
+/// Transaction representation used in execute call.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ScriptTransaction {
+    /// Script bytecode.
+    pub bytecode: Vec<u8>,
+    /// Script args.
+    pub args: Vec<Vec<u8>>,
+    /// Script type arguments.
+    pub type_args: Vec<TypeTag>,
+}
+
+impl TryFrom<&[u8]> for ScriptTransaction {
+    type Error = Error;
+
+    fn try_from(blob: &[u8]) -> Result<Self, Self::Error> {
+        bcs::from_bytes(blob).map_err(Error::msg)
+    }
+}
+
+impl ScriptTransaction {
+    /// Serializes data.
+    pub fn encode(self) -> Result<Vec<u8>> {
+        bcs::to_bytes(&self).map_err(Error::msg)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,16 +28,19 @@ enum SmoveCommand {
     #[clap(flatten)]
     MoveCommand(move_cli::Command),
 
-    /// Create package bundle.
-    #[clap(about = "Create package bundle")]
+    /// Create a package bundle.
+    #[clap(about = "Create a package bundle")]
     Bundle {
         #[clap(flatten)]
         cmd: cmd::bundle::Bundle,
     },
 
-    /// Run the script and create a transcation for the pallet.
-    #[clap(about = "Run the script and create a transcation for the pallet")]
-    Run {},
+    /// Create a script transaction.
+    #[clap(about = "Create a script transaction")]
+    CreateTransaction {
+        #[clap(flatten)]
+        cmd: cmd::script::CreateTransaction,
+    },
 
     /// Commands for accessing the node.
     #[clap(about = "Commands for accessing the node")]
@@ -61,6 +64,6 @@ pub fn smove_cli(cwd: PathBuf) -> Result<()> {
         SmoveCommand::MoveCommand(cmd) => run_move_cli::run_command(&ctx, cmd),
         SmoveCommand::Bundle { mut cmd } => cmd.execute(&ctx),
         SmoveCommand::Node(mut cmd) => cmd.execute(),
-        SmoveCommand::Run {} => unimplemented!(),
+        SmoveCommand::CreateTransaction { mut cmd } => cmd.execute(&ctx),
     }
 }

--- a/src/run_context.rs
+++ b/src/run_context.rs
@@ -11,7 +11,7 @@ use move_vm_backend_common::gas_schedule::{INSTRUCTION_COST_TABLE, NATIVE_COST_P
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use move_vm_test_utils::gas_schedule::CostTable;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Move compilation related data.
 pub struct RunContext {
@@ -58,7 +58,7 @@ impl RunContext {
     }
 
     /// Path where bundles are generated.
-    pub fn bundle_output_path(&self, bundle_name: &str) -> Result<PathBuf, Error> {
+    pub fn bundle_output_path(&self, bundle_name: &impl AsRef<Path>) -> Result<PathBuf, Error> {
         let package_name = self.manifest()?.package.name.as_str();
 
         // Create directory "<PACKAGE_PATH>/build/<PACKAGE_NAME>/bundles/"
@@ -73,6 +73,24 @@ impl RunContext {
         }
 
         Ok(dir.join(bundle_name).with_extension("mvb"))
+    }
+
+    /// Path where script transactions are generated.
+    pub fn script_tx_output_path(&self, tx_name: &impl AsRef<Path>) -> Result<PathBuf, Error> {
+        let package_name = self.manifest()?.package.name.as_str();
+
+        // Create directory "<PACKAGE_PATH>/build/<PACKAGE_NAME>/script_transactions/"
+        let dir = self
+            .project_root_dir
+            .join(CompiledPackageLayout::Root.path())
+            .join(package_name)
+            .join("script_transactions");
+
+        if !dir.exists() {
+            fs::create_dir_all(&dir)?;
+        }
+
+        Ok(dir.join(tx_name).with_extension("mvt"))
     }
 
     /// Get paths for all compiled modules without dependencies.


### PR DESCRIPTION
For now, the `smove create-transaction` command only verifies the provided file is an actual compiled Move script.

Some examples:
```
simple_scripts git:(main) smove create-transaction --compiled-script-path Move.toml
Error: Cannot deserialize the Move script:
PartialVMError with status BAD_MAGIC
```
```
simple_scripts git:(main) smove create-transaction --compiled-script-path build/simple_scripts/bytecode_scripts/empty_loop_param.mv
Script transaction is created under: /home/user/.../simple_scripts/build/simple_scripts/script_transactions/empty_loop_param.mvt
```
```
simple_scripts git:(main) smove create-transaction --compiled-script-path /tmp/no_file_here
Error: Can't read '/tmp/no_file_here':
No such file or directory (os error 2)
```