### PR TITLE
feat: type_args for create transaction cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bcs"
@@ -208,9 +208,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bitmaps"
@@ -301,7 +301,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hex"
@@ -1304,9 +1304,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1376,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -1429,7 +1429,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -1442,9 +1442,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1539,7 +1539,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "hashbrown 0.14.3",
@@ -1552,12 +1552,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1572,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "fail",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "clap",
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1661,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "difference",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "clap",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "codespan",
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "hex",
@@ -1832,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "hex",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "codespan",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -2001,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -2028,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "hex",
  "log",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "once_cell",
  "serde 1.0.195",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -2093,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "better_any",
@@ -2124,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "move-vm-backend-common"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
@@ -2143,7 +2143,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "better_any",
  "fail",
@@ -2160,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "move-vm-support"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2171,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "lazy_static 1.4.0",
@@ -2184,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
  "move-binary-format",
@@ -2336,7 +2336,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.4",
  "libc",
 ]
 
@@ -2363,11 +2363,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.62"
+version = "0.10.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2395,9 +2395,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.98"
+version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
@@ -2685,9 +2685,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -2841,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -2851,9 +2851,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -2877,7 +2877,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#b633a257fa16d4250881b4a0ccb567405cc26ac0"
+source = "git+https://github.com/eigerco/substrate-move.git#4e3f0b89a417ac67612e455e91ec4c821c602986"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3036,11 +3036,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3411,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smove"
@@ -3899,9 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -3996,9 +3996,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4006,9 +4006,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -4021,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4033,9 +4033,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4043,9 +4043,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4056,15 +4056,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3,5 +3,6 @@
 pub(super) mod bundle;
 pub(super) mod node;
 pub(super) mod script;
+pub(super) mod script_args;
 
 mod script_transaction;

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -1,11 +1,11 @@
+use super::script_args::ScriptFunctionArguments;
+use super::script_transaction::ScriptTransaction;
+use crate::run_context::RunContext;
 use anyhow::{Error, Result};
 use clap::Parser;
 use move_binary_format::file_format::CompiledScript;
 use std::fs;
 use std::path::PathBuf;
-
-use super::script_transaction::ScriptTransaction;
-use crate::run_context::RunContext;
 
 /// Create a script transaction.
 #[derive(Parser, Debug)]
@@ -13,7 +13,10 @@ use crate::run_context::RunContext;
 pub struct CreateTransaction {
     #[clap(short, long, help = "Path for the compiled Move script.")]
     compiled_script_path: PathBuf,
-    // TODO(rqnsom): add script parameters here.
+
+    /// Arguments for script functions.
+    #[clap(flatten)]
+    script_function_args: ScriptFunctionArguments,
 }
 
 impl CreateTransaction {
@@ -26,11 +29,13 @@ impl CreateTransaction {
         // Check the script bytecode and verify the parameter rules.
         verify_script_integrity(&script_bc)?;
 
+        let type_args = self.script_function_args.type_args()?;
+
         // TODO(Rqnsom): maybe use a function to create this:
         let tx = ScriptTransaction {
             bytecode: script_bc,
             args: vec![],
-            type_args: vec![],
+            type_args,
         };
 
         // Path to the output file.

--- a/src/cmd/script_args/mod.rs
+++ b/src/cmd/script_args/mod.rs
@@ -1,0 +1,30 @@
+use clap::Parser;
+use move_core_types::language_storage::TypeTag;
+use type_args::TypeArgVec;
+
+mod type_args;
+
+/// Arguments for script functions.
+#[derive(Debug, Parser)]
+pub struct ScriptFunctionArguments {
+    /// Type args.
+    #[clap(flatten)]
+    type_arg_vec: TypeArgVec,
+    //TODO(rqnsom): impl below in the next PR
+    //#[clap(flatten)]
+    //arg_vec: ArgWithTypeVec,
+}
+
+impl ScriptFunctionArguments {
+    /// Get type args.
+    pub fn type_args(&self) -> anyhow::Result<Vec<TypeTag>> {
+        let mut type_args = vec![];
+
+        for arg in self.type_arg_vec.type_args.iter() {
+            let type_arg: TypeTag = arg.try_into()?;
+            type_args.push(type_arg);
+        }
+
+        Ok(type_args)
+    }
+}

--- a/src/cmd/script_args/type_args.rs
+++ b/src/cmd/script_args/type_args.rs
@@ -1,0 +1,176 @@
+use clap::Parser;
+use move_core_types::language_storage::TypeTag;
+use move_core_types::parser::parse_type_tag;
+use std::{fmt, str::FromStr};
+
+/// TypeTag vector container.
+#[derive(Debug, Parser)]
+pub struct TypeArgVec {
+    /// TypeTag arguments separated by spaces.
+    ///
+    /// Example: `u8 u16 u32 u64 u128 u256 bool address vector signer`.
+    #[clap(long, multiple_values(true))]
+    pub(super) type_args: Vec<MoveType>,
+}
+
+// This function cannot handle the full range of types that MoveType can
+// represent. Internally, it uses parse_type_tag, which cannot handle references
+// or generic type parameters. This function adds nominal support for references
+// on top of parse_type_tag, but it still does not work for generic type params.
+// For that, we have the Unparsable variant of MoveType, so the deserialization
+// doesn't fail when dealing with these values.
+impl FromStr for MoveType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut s = s;
+        let mut is_ref = false;
+        let mut is_mut = false;
+
+        if s.starts_with('&') {
+            s = &s[1..];
+            is_ref = true;
+        }
+        if is_ref && s.starts_with("mut ") {
+            s = &s[4..];
+            is_mut = true;
+        }
+        // Previously this would just crap out, but this meant the API could
+        // return a serialized version of an object and not be able to
+        // deserialize it using that same object.
+        let inner = match parse_type_tag(s) {
+            Ok(inner) => inner.into(),
+            Err(_e) => MoveType::Unparsable(s.to_string()),
+        };
+        if is_ref {
+            Ok(MoveType::Reference {
+                mutable: is_mut,
+                to: Box::new(inner),
+            })
+        } else {
+            Ok(inner)
+        }
+    }
+}
+
+impl From<TypeTag> for MoveType {
+    fn from(tag: TypeTag) -> Self {
+        match tag {
+            TypeTag::Bool => MoveType::Bool,
+            TypeTag::U8 => MoveType::U8,
+            TypeTag::U16 => MoveType::U16,
+            TypeTag::U32 => MoveType::U32,
+            TypeTag::U64 => MoveType::U64,
+            TypeTag::U256 => MoveType::U256,
+            TypeTag::U128 => MoveType::U128,
+            TypeTag::Address => MoveType::Address,
+            TypeTag::Signer => MoveType::Signer,
+            TypeTag::Vector(v) => MoveType::Vector {
+                items: Box::new(MoveType::from(*v)),
+            },
+            TypeTag::Struct(_) => unreachable!("not supported by smove"),
+        }
+    }
+}
+
+impl From<&TypeTag> for MoveType {
+    fn from(tag: &TypeTag) -> Self {
+        match tag {
+            TypeTag::Bool => MoveType::Bool,
+            TypeTag::U8 => MoveType::U8,
+            TypeTag::U16 => MoveType::U16,
+            TypeTag::U32 => MoveType::U32,
+            TypeTag::U64 => MoveType::U64,
+            TypeTag::U128 => MoveType::U128,
+            TypeTag::U256 => MoveType::U256,
+            TypeTag::Address => MoveType::Address,
+            TypeTag::Signer => MoveType::Signer,
+            TypeTag::Vector(v) => MoveType::Vector {
+                items: Box::new(MoveType::from(v.as_ref())),
+            },
+            TypeTag::Struct(_) => unreachable!("not supported by smove"),
+        }
+    }
+}
+
+impl TryFrom<&MoveType> for TypeTag {
+    type Error = anyhow::Error;
+
+    fn try_from(tag: &MoveType) -> anyhow::Result<Self> {
+        let ret = match tag {
+            MoveType::Bool => TypeTag::Bool,
+            MoveType::U8 => TypeTag::U8,
+            MoveType::U16 => TypeTag::U16,
+            MoveType::U32 => TypeTag::U32,
+            MoveType::U64 => TypeTag::U64,
+            MoveType::U128 => TypeTag::U128,
+            MoveType::U256 => TypeTag::U256,
+            MoveType::Address => TypeTag::Address,
+            MoveType::Signer => TypeTag::Signer,
+            MoveType::Vector { items } => TypeTag::Vector(Box::new(items.as_ref().try_into()?)),
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid move type for converting into `TypeTag`: {tag:?}",
+                ))
+            }
+        };
+        Ok(ret)
+    }
+}
+
+/// An enum of Move's possible types on-chain.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MoveType {
+    /// A bool type.
+    Bool,
+    /// An 8-bit unsigned int.
+    U8,
+    /// A 16-bit unsigned int.
+    U16,
+    /// A 32-bit unsigned int.
+    U32,
+    /// A 64-bit unsigned int.
+    U64,
+    /// A 128-bit unsigned int.
+    U128,
+    /// A 256-bit unsigned int.
+    U256,
+    /// A 32-byte account address.
+    Address,
+    /// An account signer.
+    Signer,
+    /// A Vector of [`MoveType`].
+    Vector { items: Box<MoveType> },
+    /// A reference
+    Reference { mutable: bool, to: Box<MoveType> },
+    /// A move type that couldn't be parsed.
+    ///
+    /// This prevents the parser from just throwing an error because one field
+    /// was unparsable, and gives the value in it.
+    Unparsable(String),
+}
+
+impl fmt::Display for MoveType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MoveType::U8 => write!(f, "u8"),
+            MoveType::U16 => write!(f, "u16"),
+            MoveType::U32 => write!(f, "u32"),
+            MoveType::U64 => write!(f, "u64"),
+            MoveType::U128 => write!(f, "u128"),
+            MoveType::U256 => write!(f, "u256"),
+            MoveType::Address => write!(f, "address"),
+            MoveType::Signer => write!(f, "signer"),
+            MoveType::Bool => write!(f, "bool"),
+            MoveType::Vector { items } => write!(f, "vector<{}>", items),
+            MoveType::Reference { mutable, to } => {
+                if *mutable {
+                    write!(f, "&mut {}", to)
+                } else {
+                    write!(f, "&{}", to)
+                }
+            }
+            MoveType::Unparsable(string) => write!(f, "unparsable<{}>", string),
+        }
+    }
+}


### PR DESCRIPTION
Include type_args for the create-transaction command.
A few quick examples:

```
simple_scripts git:(main) smove create-transaction --compiled-script-path empty_loop_param.mv --type-args u8 u16 u32 u64 u128 u256 bool address 412

ScriptFunctionArguments { type_arg_vec: TypeArgVec { type_args: [U8, U16, U32, U64, U128, U256, Bool, Address, Unparsable("412")] } }

Error: Invalid move type for converting into `TypeTag`:
Unparsable("412")
```

```
simple_scripts git:(main) smove create-transaction --compiled-script-path empty_loop_param.mv --type-args u8 u16 u32 u64 u128 u256 bool address "vector<u16>"

ScriptFunctionArguments { type_arg_vec: TypeArgVec { type_args: [U8, U16, U32, U64, U128, U256, Bool, Address, Vector { items: U16 }] } }

Script transaction is created at:
/home/user/substrate-move/move-vm-backend/tests/assets/move-projects/simple_scripts/build/simple_scripts/script_transactions/empty_loop_param.mvt
```

Note: `type_args.rs` has been inspired by `aptos-core/api/types/src/move_types.rs`