### PR TITLE
feat: `args` for the create-transaction cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,6 +3422,7 @@ dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git)",
  "clap",
+ "hex",
  "jsonrpsee",
  "move-binary-format",
  "move-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 jsonrpsee = { version = "0.21", features = [ "http-client"] }

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -30,11 +30,12 @@ impl CreateTransaction {
         verify_script_integrity(&script_bc)?;
 
         let type_args = self.script_function_args.type_args()?;
+        let args = self.script_function_args.args()?;
 
         // TODO(Rqnsom): maybe use a function to create this:
         let tx = ScriptTransaction {
             bytecode: script_bc,
-            args: vec![],
+            args,
             type_args,
         };
 

--- a/src/cmd/script_args/args.rs
+++ b/src/cmd/script_args/args.rs
@@ -1,0 +1,269 @@
+use anyhow::{format_err, Error, Result};
+use clap::Parser;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::u256::U256;
+use serde::{Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Clone, Debug, Parser)]
+pub(super) struct ArgWithTypeVec {
+    /// Arguments combined with their type separated by spaces.
+    ///
+    /// Supported types [address, bool, hex, string, u8, u16, u32, u64, u128, u256, raw].
+    ///
+    /// Vectors may be specified using JSON array literal syntax (you may need to escape this with
+    /// quotes based on your shell interpreter).
+    ///
+    /// Example: `address:0x1 bool:true u8:0 u256:1234 "bool:[true, false]" 'address:[["0xace", "0xbee"], []]'`
+    #[clap(long, multiple_values(true))]
+    pub(super) args: Vec<ArgWithType>,
+}
+
+/// A parseable arg with a type separated by a colon.
+#[derive(Clone, Debug)]
+pub(super) struct ArgWithType {
+    vector_depth: u8,
+    pub(super) arg: Vec<u8>,
+}
+
+/// Does not support string arguments that contain the following characters:
+///
+/// * `,`
+/// * `[`
+/// * `]`
+impl FromStr for ArgWithType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Splits on the first colon, returning at most two elements.
+        // This is required to support args that contain a colon.
+        let parts: Vec<_> = s.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            return Err(Error::msg(
+                "Arguments must be pairs of <type>:<arg> e.g. bool:true".to_string(),
+            ));
+        }
+
+        // These unwraps can't fail.
+        let ty = FunctionArgType::from_str(parts.first().unwrap())?;
+        let mut arg = String::from(*parts.last().unwrap());
+        // May need to surround with quotes if not an array, so arg can be parsed into JSON.
+        if !arg.starts_with('[') {
+            if let FunctionArgType::Address
+            | FunctionArgType::Hex
+            | FunctionArgType::String
+            | FunctionArgType::Raw = ty
+            {
+                arg = format!("\"{arg}\"");
+            }
+        }
+
+        let json = serde_json::from_str::<serde_json::Value>(arg.as_str()).map_err(Error::msg)?;
+        ty.parse_arg_json(&json)
+    }
+}
+
+/// Type of the function argument.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum FunctionArgType {
+    Address,
+    Bool,
+    Hex,
+    String,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+    Raw,
+}
+
+impl fmt::Display for FunctionArgType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FunctionArgType::Address => write!(f, "address"),
+            FunctionArgType::Bool => write!(f, "bool"),
+            FunctionArgType::Hex => write!(f, "hex"),
+            FunctionArgType::String => write!(f, "string"),
+            FunctionArgType::U8 => write!(f, "u8"),
+            FunctionArgType::U16 => write!(f, "u16"),
+            FunctionArgType::U32 => write!(f, "u32"),
+            FunctionArgType::U64 => write!(f, "u64"),
+            FunctionArgType::U128 => write!(f, "u128"),
+            FunctionArgType::U256 => write!(f, "u256"),
+            FunctionArgType::Raw => write!(f, "raw"),
+        }
+    }
+}
+
+impl FunctionArgType {
+    /// Parse a standalone argument (not a vector) from string slice into BCS representation.
+    fn parse_arg_str(&self, arg: &str) -> Result<Vec<u8>> {
+        match self {
+            FunctionArgType::Address => {
+                bcs::to_bytes(&AccountAddress::from_str(arg).map_err(Error::msg)?)
+                    .map_err(Error::msg)
+            }
+            FunctionArgType::Bool => {
+                bcs::to_bytes(&bool::from_str(arg).map_err(Error::msg)?).map_err(Error::msg)
+            }
+            FunctionArgType::Hex => {
+                bcs::to_bytes(HexEncodedBytes::from_str(arg).map_err(Error::msg)?.inner())
+                    .map_err(Error::msg)
+            }
+            FunctionArgType::String => bcs::to_bytes(arg).map_err(Error::msg),
+            FunctionArgType::U8 => {
+                bcs::to_bytes(&u8::from_str(arg).map_err(Error::msg)?).map_err(Error::msg)
+            }
+            FunctionArgType::U16 => {
+                bcs::to_bytes(&u16::from_str(arg).map_err(Error::msg)?).map_err(Error::msg)
+            }
+            FunctionArgType::U32 => bcs::to_bytes(&u32::from_str(arg)?).map_err(Error::msg),
+            FunctionArgType::U64 => bcs::to_bytes(&u64::from_str(arg)?).map_err(Error::msg),
+            FunctionArgType::U128 => {
+                bcs::to_bytes(&u128::from_str(arg).map_err(Error::msg)?).map_err(Error::msg)
+            }
+            FunctionArgType::U256 => {
+                bcs::to_bytes(&U256::from_str(arg).map_err(Error::msg)?).map_err(Error::msg)
+            }
+            FunctionArgType::Raw => Ok(HexEncodedBytes::from_str(arg)
+                .map_err(Error::msg)?
+                .inner()
+                .to_vec()),
+        }
+    }
+
+    /// Recursively parse argument JSON into BCS representation.
+    fn parse_arg_json(&self, arg: &serde_json::Value) -> Result<ArgWithType> {
+        match arg {
+            serde_json::Value::Bool(value) => Ok(ArgWithType {
+                vector_depth: 0,
+                arg: self.parse_arg_str(value.to_string().as_str())?,
+            }),
+            serde_json::Value::Number(value) => Ok(ArgWithType {
+                vector_depth: 0,
+                arg: self.parse_arg_str(value.to_string().as_str())?,
+            }),
+            serde_json::Value::String(value) => Ok(ArgWithType {
+                vector_depth: 0,
+                arg: self.parse_arg_str(value.as_str())?,
+            }),
+            serde_json::Value::Array(_) => {
+                let mut bcs: Vec<u8> = vec![]; // BCS representation of argument.
+                let mut common_sub_arg_depth = None;
+                // Prepend argument sequence length to BCS bytes vector.
+                write_u64_as_uleb128(&mut bcs, arg.as_array().unwrap().len());
+                // Loop over all of the vector's sub-arguments, which may also be vectors:
+                for sub_arg in arg.as_array().unwrap() {
+                    let ArgWithType {
+                        vector_depth: sub_arg_depth,
+                        arg: mut sub_arg_bcs,
+                    } = self.parse_arg_json(sub_arg)?;
+                    // Verify all sub-arguments have same depth.
+                    if let Some(check_depth) = common_sub_arg_depth {
+                        if check_depth != sub_arg_depth {
+                            return Err(Error::msg("Variable vector depth".to_string()));
+                        }
+                    };
+                    common_sub_arg_depth = Some(sub_arg_depth);
+                    bcs.append(&mut sub_arg_bcs); // Append sub-argument BCS.
+                }
+                // Default sub-argument depth is 0 for when no sub-arguments were looped over.
+                Ok(ArgWithType {
+                    vector_depth: common_sub_arg_depth.unwrap_or(0) + 1,
+                    arg: bcs,
+                })
+            }
+            serde_json::Value::Null => Err(Error::msg("Null argument".to_string())),
+            serde_json::Value::Object(_) => Err(Error::msg("JSON object argument".to_string())),
+        }
+    }
+}
+
+// A copied function from: substrate-move/language/move-binary-format/src/file_format_common.rs
+// since that function is still not a public function.
+fn write_u64_as_uleb128(binary: &mut Vec<u8>, mut val: usize) {
+    loop {
+        let cur = val & 0x7F;
+        if cur != val {
+            binary.push((cur | 0x80) as u8);
+            val >>= 7;
+        } else {
+            binary.push(cur as u8);
+            break;
+        }
+    }
+}
+
+impl FromStr for FunctionArgType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "address" => Ok(FunctionArgType::Address),
+            "bool" => Ok(FunctionArgType::Bool),
+            "hex" => Ok(FunctionArgType::Hex),
+            "string" => Ok(FunctionArgType::String),
+            "u8" => Ok(FunctionArgType::U8),
+            "u16" => Ok(FunctionArgType::U16),
+            "u32" => Ok(FunctionArgType::U32),
+            "u64" => Ok(FunctionArgType::U64),
+            "u128" => Ok(FunctionArgType::U128),
+            "u256" => Ok(FunctionArgType::U256),
+            "raw" => Ok(FunctionArgType::Raw),
+            wrong_arg => {Err(Error::msg(format!(
+                "Invalid arg type '{wrong_arg}'.  Must be one of: ['{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}']",
+                FunctionArgType::Address,
+                FunctionArgType::Bool,
+                FunctionArgType::Hex,
+                FunctionArgType::String,
+                FunctionArgType::U8,
+                FunctionArgType::U16,
+                FunctionArgType::U32,
+                FunctionArgType::U64,
+                FunctionArgType::U128,
+                FunctionArgType::U256,
+                FunctionArgType::Raw)))
+            }
+        }
+    }
+}
+
+/// Hex encoded bytes to allow for having bytes represented in JSON.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HexEncodedBytes(Vec<u8>);
+
+impl FromStr for HexEncodedBytes {
+    type Err = Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self, anyhow::Error> {
+        let hex_str = if let Some(hex) = s.strip_prefix("0x") {
+            hex
+        } else {
+            s
+        };
+        Ok(Self(hex::decode(hex_str).map_err(|e| {
+            format_err!("decode hex-encoded string({s:?}) failed, caused by error: {e}",)
+        })?))
+    }
+}
+
+impl fmt::Display for HexEncodedBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{}", hex::encode(&self.0))
+    }
+}
+
+impl Serialize for HexEncodedBytes {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl HexEncodedBytes {
+    fn inner(&self) -> &[u8] {
+        &self.0
+    }
+}

--- a/src/cmd/script_args/mod.rs
+++ b/src/cmd/script_args/mod.rs
@@ -1,7 +1,10 @@
+use anyhow::Result;
+use args::ArgWithTypeVec;
 use clap::Parser;
 use move_core_types::language_storage::TypeTag;
 use type_args::TypeArgVec;
 
+mod args;
 mod type_args;
 
 /// Arguments for script functions.
@@ -10,14 +13,15 @@ pub struct ScriptFunctionArguments {
     /// Type args.
     #[clap(flatten)]
     type_arg_vec: TypeArgVec,
-    //TODO(rqnsom): impl below in the next PR
-    //#[clap(flatten)]
-    //arg_vec: ArgWithTypeVec,
+
+    /// Function args.
+    #[clap(flatten)]
+    arg_vec: ArgWithTypeVec,
 }
 
 impl ScriptFunctionArguments {
-    /// Get type args.
-    pub fn type_args(&self) -> anyhow::Result<Vec<TypeTag>> {
+    /// Get type arguments.
+    pub fn type_args(&self) -> Result<Vec<TypeTag>> {
         let mut type_args = vec![];
 
         for arg in self.type_arg_vec.type_args.iter() {
@@ -26,5 +30,15 @@ impl ScriptFunctionArguments {
         }
 
         Ok(type_args)
+    }
+
+    /// Get function arguments.
+    pub fn args(&self) -> Result<Vec<Vec<u8>>> {
+        Ok(self
+            .arg_vec
+            .args
+            .iter()
+            .map(|arg_with_type| arg_with_type.arg.clone())
+            .collect())
     }
 }


### PR DESCRIPTION
This is actually a partial implementation, what is missing here:
 - support for the signer argument
 - SS58 address parsing

A few test examples (using pallet-move/assets/move-projects/):

--- Successes (in the template node) ---

```
smove create-transaction --compiled-script-path
build/move-basics/bytecode_scripts/empty_scr.mv
Script transaction is created at:
[…]/move-basics/script_transactions/empty_scr.mvt
```
```
smove create-transaction --compiled-script-path
build/move-basics/bytecode_scripts/empty_loop_param.mv --args u64:32
Script transaction is created at:
[…]/move-projects/move-basics/build/move-basics/script_transactions/empty_loop_param.mvt
```
```
smove create-transaction --compiled-script-path
build/move-basics/bytecode_scripts/generic_1.mv --args u64:32
--type-args u64
Script transaction is created at:
[…]/move-basics/build/move-basics/script_transactions/generic_1.mvt
```

--- Errors (in the template node) ---

OutOfGas error:
```
smove create-transaction --compiled-script-path
build/move-basics/bytecode_scripts/empty_loop_param.mv --args u64:32
Script transaction is created at:
[…]/move-projects/move-basics/build/move-basics/script_transactions/empty_loop_param.mvt
```

FailedToDeserializeArgument error:
```
smove create-transaction --compiled-script-path
build/move-basics/bytecode_scripts/empty_loop_param.mv --args u32:4
Script transaction is created at:
[…]/move-projects/move-basics/build/move-basics/script_transactions/empty_loop_param.mvt
```

NumberOfArgumentsMismatch error:
```
smove create-transaction --compiled-script-path
build/move-basics/bytecode_scripts/empty_scr.mv --args bool:true
Script transaction is created at:
[…]/move-basics/script_transactions/empty_scr.mvt
```

NumberOfTypeArgumentsMismatch error:
```
smove create-transaction --compiled-script-path
build/move-basics/bytecode_scripts/generic_1.mv --args u64:32
Script transaction is created at:
[…]/move-basics/build/move-basics/script_transactions/generic_1.mvt
```