### PR TITLE
feat: ss58 parsing support in create-tx cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,6 +3432,7 @@ dependencies = [
  "move-stdlib",
  "move-vm-backend-common",
  "move-vm-runtime",
+ "move-vm-support",
  "move-vm-test-utils",
  "serde 1.0.195",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ move-vm-runtime = { git = "https://github.com/eigerco/substrate-move.git" }
 move-command-line-common = { git = "https://github.com/eigerco/substrate-move.git" }
 move-binary-format = { git = "https://github.com/eigerco/substrate-move.git" }
 move-vm-backend-common = { git = "https://github.com/eigerco/substrate-move.git", features = ["gas_schedule", "testing"] }
+move-vm-support = { git = "https://github.com/eigerco/substrate-move.git" }


### PR DESCRIPTION
Parse the address which can have multiple formats.
 - Move address format
   - Strict raw 32-hex format (e.g. 1234abce5678ef901234abce5678ef901234abce5678ef901234abce5678ef90)
   - Flexible prefixed hex format (e.g. 0x5)
 - SS58 address format
   - e.g. 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694t