### PR TITLE
feat: add script verification for create-tx cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/eigerco/bcs.git?branch=master#850598d0cb128f10ecf4ce87ff94281ee46e6524"
 dependencies = [
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/eigerco/bcs.git#850598d0cb128f10ecf4ce87ff94281ee46e6524"
 dependencies = [
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
- "serde 1.0.195",
+ "serde 1.0.196",
  "thiserror",
 ]
 
@@ -178,7 +178,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -301,7 +301,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -425,7 +425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -434,7 +434,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.195",
+ "serde 1.0.196",
  "termcolor",
  "unicode-width",
 ]
@@ -468,7 +468,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom",
  "rust-ini",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -708,7 +708,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "serde 1.0.195",
+ "serde 1.0.196",
  "signature",
 ]
 
@@ -721,7 +721,7 @@ dependencies = [
  "curve25519-dalek-fiat",
  "ed25519",
  "rand",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -999,7 +999,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1334,7 +1334,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "jsonrpsee-types",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1352,7 +1352,7 @@ dependencies = [
  "hyper-rustls",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1369,7 +1369,7 @@ checksum = "3266dfb045c9174b24c77c2dfe0084914bb23a6b2597d70c9dc6018392e1cd1b"
 dependencies = [
  "anyhow",
  "beef",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_json",
  "thiserror",
 ]
@@ -1462,7 +1462,7 @@ version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1533,31 +1533,31 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "hashbrown 0.14.3",
  "move-core-types",
  "ref-cast",
- "serde 1.0.195",
+ "serde 1.0.196",
  "variant_count",
 ]
 
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1566,13 +1566,13 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "fail",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "clap",
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1650,7 +1650,7 @@ dependencies = [
  "read-write-set",
  "read-write-set-dynamic",
  "reqwest",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -1661,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "difference",
@@ -1671,7 +1671,7 @@ dependencies = [
  "move-vm-support",
  "num-bigint",
  "once_cell",
- "serde 1.0.195",
+ "serde 1.0.196",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
@@ -1722,7 +1722,7 @@ dependencies = [
  "rand",
  "ref-cast",
  "scale-info",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_bytes",
  "uint",
 ]
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1744,13 +1744,13 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "clap",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "codespan",
@@ -1780,13 +1780,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1794,13 +1794,13 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "hex",
@@ -1832,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "hex",
@@ -1840,13 +1840,13 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "codespan",
@@ -1866,13 +1866,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1897,7 +1897,7 @@ dependencies = [
  "ptree",
  "regex",
  "reqwest",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_yaml",
  "sha2 0.9.9",
  "tempfile",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1936,7 +1936,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_json",
  "simplelog",
  "tokio",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1966,7 +1966,7 @@ dependencies = [
  "pretty",
  "rand",
  "regex",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_json",
  "tera",
  "tokio",
@@ -1975,18 +1975,18 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1995,13 +1995,13 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -2022,13 +2022,13 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -2040,13 +2040,13 @@ dependencies = [
  "move-model",
  "move-stackless-bytecode",
  "num",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "hex",
  "log",
@@ -2067,16 +2067,16 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "once_cell",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -2093,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "better_any",
@@ -2124,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "move-vm-backend-common"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
@@ -2132,18 +2132,19 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-stdlib",
+ "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_bytes",
 ]
 
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "better_any",
  "fail",
@@ -2160,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "move-vm-support"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2171,25 +2172,25 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "lazy_static 1.4.0",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.195",
+ "serde 1.0.196",
  "smallvec",
 ]
 
@@ -2454,7 +2455,7 @@ dependencies = [
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -2463,7 +2464,7 @@ version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2600,7 +2601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
 ]
 
 [[package]]
@@ -2610,7 +2611,7 @@ source = "git+https://github.com/eigerco/petgraph.git?branch=master#1d8299983104
 dependencies = [
  "fixedbitset 0.4.2",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
 ]
 
 [[package]]
@@ -2728,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
 dependencies = [
  "toml_datetime",
  "toml_edit 0.20.2",
@@ -2780,7 +2781,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde-value",
  "tint",
 ]
@@ -2862,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -2877,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#9288fc8f0c06034220002160f48c7296c06921b8"
+source = "git+https://github.com/eigerco/substrate-move.git#74e5a00ba83c110e12075afea878fe05b1864c11"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -2988,7 +2989,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
@@ -3186,9 +3187,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -3212,7 +3213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
- "serde 1.0.195",
+ "serde 1.0.196",
  "thiserror",
 ]
 
@@ -3223,7 +3224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -3232,14 +3233,14 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3248,13 +3249,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -3266,7 +3267,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -3277,7 +3278,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap 1.9.3",
  "ryu",
- "serde 1.0.195",
+ "serde 1.0.196",
  "yaml-rust",
 ]
 
@@ -3434,7 +3435,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-support",
  "move-vm-test-utils",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_json",
  "tokio",
 ]
@@ -3563,7 +3564,7 @@ dependencies = [
  "pest_derive",
  "rand",
  "regex",
- "serde 1.0.195",
+ "serde 1.0.196",
  "serde_json",
  "slug",
  "unic-segment",
@@ -3698,7 +3699,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -3716,7 +3717,7 @@ dependencies = [
  "combine",
  "indexmap 1.9.3",
  "itertools",
- "serde 1.0.195",
+ "serde 1.0.196",
 ]
 
 [[package]]
@@ -3725,7 +3726,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "toml_datetime",
  "winnow",
 ]
@@ -3736,7 +3737,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.1",
  "toml_datetime",
  "winnow",
 ]
@@ -4262,9 +4263,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
We can check if the input parameter list for the given script is valid and notify the user already at this early level of deployment.

An example in case of failure:
```
➜  bytecode_scripts git:(main) smove create-transaction --compiled-script-path extra_signer_in_the_middle_of_the_list.mv
Error: Script parameters verification failure INVALID_MAIN_FUNCTION_SIGNATURE
```