### PR TITLE
chore: add the url option for the node command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,6 +3438,7 @@ dependencies = [
  "serde 1.0.196",
  "serde_json",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ jsonrpsee = { version = "0.21", features = [ "http-client"] }
 tokio = { version = "1.35", features = ["rt", "time", "net"] }
 anyhow = "1.0"
 # Keep the version aligned with the clap version in the upstream repo https://github.com/move-language/move
+url = "2.5"
 clap = { version = "3.2", features = ["derive"] }
 bcs = { git = "https://github.com/eigerco/bcs.git" }
 move-cli = { git = "https://github.com/eigerco/substrate-move.git" }

--- a/src/cmd/node/mod.rs
+++ b/src/cmd/node/mod.rs
@@ -1,19 +1,41 @@
 use anyhow::Result;
+use clap::Parser;
+use url::Url;
 
 mod rpc;
 
 /// Commands for accessing the node.
-#[derive(clap::Subcommand)]
-pub enum Node {
+#[derive(Parser)]
+pub struct Node {
+    /// Command option.
+    #[clap(subcommand)]
+    node_cmd: NodeCmd,
+
+    /// URL for the node's endpoint depending on the chosen option.
+    #[clap(
+        short,
+        long,
+        help = "Node's URL (by default using local RPC's URL)",
+        default_value = "http://localhost:9944/"
+    )]
+    url: Url,
+}
+
+/// List of possible node access commands.
+#[derive(Parser)]
+pub enum NodeCmd {
+    /// Access node's RPC requests.
     #[clap(subcommand, about = "Access node's RPC requests")]
     Rpc(Rpc),
+    // TODO: Future possibility
+    //Extrinsic(Extrinsic)
 }
 
 impl Node {
     /// Executes the command.
     pub fn execute(&mut self) -> Result<()> {
-        match self {
-            Self::Rpc(cmd) => cmd.execute(),
+        match &self.node_cmd {
+            NodeCmd::Rpc(rpc) => rpc.execute(&self.url),
         }
     }
 }
@@ -51,12 +73,12 @@ pub enum Rpc {
 
 impl Rpc {
     /// Executes the command.
-    pub fn execute(&mut self) -> Result<()> {
+    pub fn execute(&self, url: &Url) -> Result<()> {
         match self {
-            Self::EstimateGasPublishModule { cmd } => cmd.execute(),
-            Self::EstimateGasPublishBundle { cmd } => cmd.execute(),
-            Self::GasToWeight { cmd } => cmd.execute(),
-            Self::GetModuleAbi { cmd } => cmd.execute(),
+            Self::EstimateGasPublishModule { cmd } => cmd.execute(url),
+            Self::EstimateGasPublishBundle { cmd } => cmd.execute(url),
+            Self::GasToWeight { cmd } => cmd.execute(url),
+            Self::GetModuleAbi { cmd } => cmd.execute(url),
         }
     }
 }

--- a/src/cmd/node/rpc/estimate_gas_publish.rs
+++ b/src/cmd/node/rpc/estimate_gas_publish.rs
@@ -7,6 +7,7 @@ use move_core_types::vm_status::StatusCode;
 use serde::Deserialize;
 use std::fmt;
 use std::path::{Path, PathBuf};
+use url::Url;
 
 /// Estimate gas for publishing modules.
 #[derive(Parser, Debug)]
@@ -20,17 +21,14 @@ pub struct EstimateGasPublishModule {
 
 impl EstimateGasPublishModule {
     /// Executes the command.
-    pub fn execute(&mut self) -> Result<()> {
-        // TODO: provide the rpc_url via the argument
-        let rpc_url = "http://localhost:9944/";
-
+    pub fn execute(&self, url: &Url) -> Result<()> {
         let script_tx = read_bytes(&self.module_path)?;
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
 
-        let client = HttpClientBuilder::default().build(rpc_url)?;
+        let client = HttpClientBuilder::default().build(url)?;
         let params = rpc_params![&self.account_id, script_tx];
         let response: Result<Estimation, _> =
             rt.block_on(async { client.request("mvm_estimateGasPublishModule", params).await });
@@ -55,17 +53,14 @@ pub struct EstimateGasPublishBundle {
 
 impl EstimateGasPublishBundle {
     /// Executes the command.
-    pub fn execute(&mut self) -> Result<()> {
-        // TODO: provide the rpc_url via the argument
-        let rpc_url = "http://localhost:9944/";
-
+    pub fn execute(&self, url: &Url) -> Result<()> {
         let script_tx = read_bytes(&self.bundle_path)?;
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
 
-        let client = HttpClientBuilder::default().build(rpc_url)?;
+        let client = HttpClientBuilder::default().build(url)?;
         let params = rpc_params![&self.account_id, script_tx];
         let response: Result<Estimation, _> =
             rt.block_on(async { client.request("mvm_estimateGasPublishBundle", params).await });

--- a/src/cmd/node/rpc/gas_to_weight.rs
+++ b/src/cmd/node/rpc/gas_to_weight.rs
@@ -5,6 +5,7 @@ use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::rpc_params;
 use serde::Deserialize;
 use std::fmt;
+use url::Url;
 
 /// Estimate gas for publishing modules.
 #[derive(Parser, Debug)]
@@ -35,15 +36,12 @@ impl fmt::Display for Weight {
 
 impl GasToWeight {
     /// Executes the command.
-    pub fn execute(&mut self) -> Result<()> {
-        // TODO: provide the rpc_url via the argument
-        let rpc_url = "http://localhost:9944/";
-
+    pub fn execute(&self, url: &Url) -> Result<()> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
 
-        let client = HttpClientBuilder::default().build(rpc_url)?;
+        let client = HttpClientBuilder::default().build(url)?;
         let params = rpc_params![self.gas];
         let response: Result<Weight, _> =
             rt.block_on(async { client.request("mvm_gasToWeight", params).await });

--- a/src/cmd/node/rpc/get_module_abi.rs
+++ b/src/cmd/node/rpc/get_module_abi.rs
@@ -4,6 +4,7 @@ use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::rpc_params;
 use move_vm_backend_common::abi::ModuleAbi;
+use url::Url;
 
 /// Estimate gas for publishing modules.
 #[derive(Parser, Debug)]
@@ -17,15 +18,12 @@ pub struct GetModuleAbi {
 
 impl GetModuleAbi {
     /// Executes the command.
-    pub fn execute(&mut self) -> Result<()> {
-        // TODO: provide the rpc_url via the argument
-        let rpc_url = "http://localhost:9944/";
-
+    pub fn execute(&self, url: &Url) -> Result<()> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
 
-        let client = HttpClientBuilder::default().build(rpc_url)?;
+        let client = HttpClientBuilder::default().build(url)?;
         let params = rpc_params![&self.address, &self.name];
         let response: Result<Option<ModuleAbi>, _> =
             rt.block_on(async { client.request("mvm_getModuleABI", params).await });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,10 @@ enum SmoveCommand {
 
     /// Commands for accessing the node.
     #[clap(about = "Commands for accessing the node")]
-    #[clap(subcommand)]
-    Node(cmd::node::Node),
+    Node {
+        #[clap(flatten)]
+        cmd: cmd::node::Node,
+    },
 }
 
 /// Run the smove CLI.
@@ -63,7 +65,7 @@ pub fn smove_cli(cwd: PathBuf) -> Result<()> {
     match cmd {
         SmoveCommand::MoveCommand(cmd) => run_move_cli::run_command(&ctx, cmd),
         SmoveCommand::Bundle { mut cmd } => cmd.execute(&ctx),
-        SmoveCommand::Node(mut cmd) => cmd.execute(),
+        SmoveCommand::Node { mut cmd } => cmd.execute(),
         SmoveCommand::CreateTransaction { mut cmd } => cmd.execute(&ctx),
     }
 }


### PR DESCRIPTION
Quick examples:
```sh
$ smove node --url http://127.0.0.1:9944 rpc gas-to-weight --gas 5
Value of 5 gas converted to weight has a value of Weight (ref_time: 1123123, proof_size: 0)
```

```sh
$ smove node --url http://127.0.0.1:5555 rpc gas-to-weight --gas 5
Error: Networking or low-level protocol error: HTTP error: error trying to connect: tcp connect error: Connection refused (os error 61)

Caused by:
    HTTP error: error trying to connect: tcp connect error: Connection refused (os error 61)
```

```sh
$ smove node rpc gas-to-weight --gas 5
Value of 5 gas converted to weight has a value of Weight (ref_time: 1123123, proof_size: 0)
```

The help output:
```sh
$ smove node
smove-node
Commands for accessing the node

USAGE:
    smove node [OPTIONS] <SUBCOMMAND>

OPTIONS:
    ... <hiding global move options> ...
    -u, --url <URL>
            Node's URL (by default using local RPC's URL) [default: http://localhost:9944/]

SUBCOMMANDS:
    help    Print this message or the help of the given subcommand(s)
    rpc     Access node's RPC requests
```