### PR TITLE
feat: add EstimateGasExecuteScript rpc sub-cmd

### DIFF
--- a/src/cmd/node/mod.rs
+++ b/src/cmd/node/mod.rs
@@ -9,7 +9,7 @@ mod rpc;
 pub struct Node {
     /// Command option.
     #[clap(subcommand)]
-    node_cmd: NodeCmd,
+    cmd: NodeCmd,
 
     /// URL for the node's endpoint depending on the chosen option.
     #[clap(
@@ -34,7 +34,7 @@ pub enum NodeCmd {
 impl Node {
     /// Executes the command.
     pub fn execute(&mut self) -> Result<()> {
-        match &self.node_cmd {
+        match &self.cmd {
             NodeCmd::Rpc(rpc) => rpc.execute(&self.url),
         }
     }
@@ -54,6 +54,13 @@ pub enum Rpc {
     EstimateGasPublishBundle {
         #[clap(flatten)]
         cmd: rpc::estimate_gas_publish::EstimateGasPublishBundle,
+    },
+
+    /// Estimate gas for executing a script.
+    #[clap(about = "Estimate gas for executing a script")]
+    EstimateGasExecuteScript {
+        #[clap(flatten)]
+        cmd: rpc::estimate_gas_execute::EstimateGasExecuteScript,
     },
 
     /// Convert gas to weight.
@@ -77,6 +84,7 @@ impl Rpc {
         match self {
             Self::EstimateGasPublishModule { cmd } => cmd.execute(url),
             Self::EstimateGasPublishBundle { cmd } => cmd.execute(url),
+            Self::EstimateGasExecuteScript { cmd } => cmd.execute(url),
             Self::GasToWeight { cmd } => cmd.execute(url),
             Self::GetModuleAbi { cmd } => cmd.execute(url),
         }

--- a/src/cmd/node/rpc/estimate_gas_execute.rs
+++ b/src/cmd/node/rpc/estimate_gas_execute.rs
@@ -1,0 +1,48 @@
+use super::{read_bytes, Estimation};
+use anyhow::{Context, Result};
+use clap::Parser;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::rpc_params;
+use std::path::PathBuf;
+use url::Url;
+
+/// Estimate gas for publishing modules.
+#[derive(Parser, Debug)]
+#[clap(about = "Estimate gas for executing script")]
+pub struct EstimateGasExecuteScript {
+    /// Account ID in the SS58 format.
+    #[clap(short, long)]
+    account_id: String,
+
+    /// Path to the script transaction (compiled by the smove create-transaction).
+    #[clap(short, long)]
+    script_transaction_path: PathBuf,
+
+    /// Cheque limit the account is willing to write from their balance account - used for
+    /// read-only and validation gas estimation purposes.
+    #[clap(short, long)]
+    cheque_limit: u128,
+}
+
+impl EstimateGasExecuteScript {
+    /// Executes the command.
+    pub fn execute(&self, url: &Url) -> Result<()> {
+        let script_tx = read_bytes(&self.script_transaction_path)?;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let client = HttpClientBuilder::default().build(url)?;
+        let params = rpc_params![&self.account_id, script_tx, self.cheque_limit];
+        let response: Result<Estimation, _> =
+            rt.block_on(async { client.request("mvm_estimateGasExecuteScript", params).await });
+
+        let estimated_gas = response.with_context(|| "RPC result failure")?;
+
+        println!("Estimated gas: {estimated_gas}");
+
+        Ok(())
+    }
+}

--- a/src/cmd/node/rpc/estimate_gas_publish.rs
+++ b/src/cmd/node/rpc/estimate_gas_publish.rs
@@ -1,12 +1,10 @@
+use super::{read_bytes, Estimation};
 use anyhow::{Context, Result};
 use clap::Parser;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::rpc_params;
-use move_core_types::vm_status::StatusCode;
-use serde::Deserialize;
-use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use url::Url;
 
 /// Estimate gas for publishing modules.
@@ -15,6 +13,7 @@ use url::Url;
 pub struct EstimateGasPublishModule {
     #[clap(short, long, help = "Account ID in the SS58 format")]
     account_id: String,
+
     #[clap(short, long, help = "Path to the module (compiled by the smove)")]
     module_path: PathBuf,
 }
@@ -47,6 +46,7 @@ impl EstimateGasPublishModule {
 pub struct EstimateGasPublishBundle {
     #[clap(short, long, help = "Account ID in the SS58 format")]
     account_id: String,
+
     #[clap(short, long, help = "Path to the bundle (compiled by the smove)")]
     bundle_path: PathBuf,
 }
@@ -71,36 +71,4 @@ impl EstimateGasPublishBundle {
 
         Ok(())
     }
-}
-
-/// Gas estimation information.
-#[derive(Deserialize)]
-struct Estimation {
-    /// Gas used.
-    gas_used: u64,
-    /// Status code for the MoveVM execution.
-    vm_status_code: StatusCode,
-}
-
-impl fmt::Display for Estimation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let gas_used = if matches!(self.vm_status_code, StatusCode::EXECUTED) {
-            self.gas_used
-        } else {
-            0
-        };
-
-        write!(
-            f,
-            "Estimate (gas_used: {}, vm_status_code: {:?})",
-            gas_used, self.vm_status_code
-        )
-    }
-}
-
-/// Reads bytes from a file for the given path.
-fn read_bytes(file_path: &Path) -> Result<Vec<u8>> {
-    std::fs::read(file_path)
-        .map_err(anyhow::Error::from)
-        .with_context(|| format!("Failure to read filename {}", file_path.display()))
 }

--- a/src/cmd/node/rpc/mod.rs
+++ b/src/cmd/node/rpc/mod.rs
@@ -1,5 +1,44 @@
 //! List of RPC commands.
 
+pub(super) mod estimate_gas_execute;
 pub(super) mod estimate_gas_publish;
 pub(super) mod gas_to_weight;
 pub(super) mod get_module_abi;
+
+use anyhow::{Context, Result};
+use move_core_types::vm_status::StatusCode;
+use serde::Deserialize;
+use std::fmt;
+use std::path::Path;
+
+/// Reads bytes from a file for the given path.
+fn read_bytes(file_path: &Path) -> Result<Vec<u8>> {
+    std::fs::read(file_path)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("Failure to read filename {}", file_path.display()))
+}
+
+/// Gas estimation information.
+#[derive(Deserialize)]
+struct Estimation {
+    /// Gas used.
+    gas_used: u64,
+    /// Status code for the MoveVM execution.
+    vm_status_code: StatusCode,
+}
+
+impl fmt::Display for Estimation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let gas_used = if matches!(self.vm_status_code, StatusCode::EXECUTED) {
+            self.gas_used
+        } else {
+            0
+        };
+
+        write!(
+            f,
+            "Estimate (gas_used: {gas_used}, vm_status_code: {:?})",
+            self.vm_status_code
+        )
+    }
+}


### PR DESCRIPTION
The command is used for estimating gas for script execution.