### PR TITLE
feat: add call hash subcommand for script transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "arrayvec"
@@ -105,7 +105,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/eigerco/bcs.git?branch=master#850598d0cb128f10ecf4ce87ff94281ee46e6524"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/eigerco/bcs.git#850598d0cb128f10ecf4ce87ff94281ee46e6524"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
  "thiserror",
 ]
 
@@ -178,7 +178,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -278,19 +278,19 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byte-slice-cast"
@@ -301,7 +301,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -330,12 +330,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 
 [[package]]
 name = "cfg-if"
@@ -345,23 +342,23 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -425,7 +422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -434,7 +431,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
  "termcolor",
  "unicode-width",
 ]
@@ -468,7 +465,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom",
  "rust-ini",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -631,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "deunicode"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae2a35373c5c74340b79ae6780b498b2b183915ec5dacf263aac5a099bf485a"
+checksum = "b6e854126756c496b8c81dec88f9a706b15b875c5849d4097a3854476b9fdf94"
 
 [[package]]
 name = "difference"
@@ -708,7 +705,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
  "signature",
 ]
 
@@ -721,7 +718,7 @@ dependencies = [
  "curve25519-dalek-fiat",
  "ed25519",
  "rand",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -729,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encoding_rs"
@@ -903,7 +900,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -999,7 +996,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.2",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1012,7 +1009,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1021,7 +1018,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -1050,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1062,9 +1059,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1251,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1274,7 +1271,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab388864246d58a276e60e7569a833d9cc4cd75c66e5ca77c177dad38e59996"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
  "dashmap",
  "hashbrown 0.12.3",
  "once_cell",
@@ -1304,9 +1301,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1334,7 +1331,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "jsonrpsee-types",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1352,7 +1349,7 @@ dependencies = [
  "hyper-rustls",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1369,7 +1366,7 @@ checksum = "3266dfb045c9174b24c77c2dfe0084914bb23a6b2597d70c9dc6018392e1cd1b"
 dependencies = [
  "anyhow",
  "beef",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "thiserror",
 ]
@@ -1458,11 +1455,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -1501,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -1522,7 +1519,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1533,31 +1530,31 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "hashbrown 0.14.3",
  "move-core-types",
  "ref-cast",
- "serde 1.0.196",
+ "serde 1.0.197",
  "variant_count",
 ]
 
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1566,13 +1563,13 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -1584,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "fail",
@@ -1598,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "clap",
@@ -1615,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1650,7 +1647,7 @@ dependencies = [
  "read-write-set",
  "read-write-set-dynamic",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -1661,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "difference",
@@ -1671,7 +1668,7 @@ dependencies = [
  "move-vm-support",
  "num-bigint",
  "once_cell",
- "serde 1.0.196",
+ "serde 1.0.197",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -1679,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1709,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
@@ -1722,7 +1719,7 @@ dependencies = [
  "rand",
  "ref-cast",
  "scale-info",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_bytes",
  "uint",
 ]
@@ -1730,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1744,13 +1741,13 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "clap",
@@ -1768,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "codespan",
@@ -1780,13 +1777,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1794,13 +1791,13 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -1819,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "hex",
@@ -1832,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "hex",
@@ -1840,13 +1837,13 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "codespan",
@@ -1866,13 +1863,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1897,7 +1894,7 @@ dependencies = [
  "ptree",
  "regex",
  "reqwest",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_yaml",
  "sha2 0.9.9",
  "tempfile",
@@ -1909,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1936,7 +1933,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "simplelog",
  "tokio",
@@ -1946,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1966,7 +1963,7 @@ dependencies = [
  "pretty",
  "rand",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "tera",
  "tokio",
@@ -1975,18 +1972,18 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -1995,13 +1992,13 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -2022,13 +2019,13 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -2040,13 +2037,13 @@ dependencies = [
  "move-model",
  "move-stackless-bytecode",
  "num",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "hex",
  "log",
@@ -2067,16 +2064,16 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "once_cell",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.6",
@@ -2093,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "better_any",
@@ -2124,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "move-vm-backend-common"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
@@ -2137,14 +2134,14 @@ dependencies = [
  "move-vm-types",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_bytes",
 ]
 
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "better_any",
  "fail",
@@ -2161,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "move-vm-support"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2172,25 +2169,25 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "lazy_static 1.4.0",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git?branch=master)",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.196",
+ "serde 1.0.197",
  "smallvec",
 ]
 
@@ -2257,7 +2254,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -2268,37 +2265,36 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -2310,7 +2306,7 @@ dependencies = [
  "autocfg",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -2319,14 +2315,14 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -2337,7 +2333,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2358,15 +2354,15 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -2385,7 +2381,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2396,9 +2392,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -2412,7 +2408,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -2455,7 +2451,7 @@ dependencies = [
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -2541,9 +2537,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2552,9 +2548,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2562,22 +2558,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
 dependencies = [
  "once_cell",
  "pest",
@@ -2601,7 +2597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.2.2",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -2611,7 +2607,7 @@ source = "git+https://github.com/eigerco/petgraph.git?branch=master#1d8299983104
 dependencies = [
  "fixedbitset 0.4.2",
  "hashbrown 0.14.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -2669,7 +2665,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2686,9 +2682,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
@@ -2781,7 +2777,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde-value",
  "tint",
 ]
@@ -2842,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -2863,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -2878,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/substrate-move.git#cd06c9abc734dca8dcb6f16c2f424b55c86d60ce"
+source = "git+https://github.com/eigerco/substrate-move.git#e7af20b82e3b3f99df5d8a22610b5117e2687e77"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -2933,7 +2929,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2950,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2990,7 +2986,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls-pemfile",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
@@ -3007,16 +3003,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin 0.9.8",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3095,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -3189,9 +3186,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -3215,7 +3212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
- "serde 1.0.196",
+ "serde 1.0.197",
  "thiserror",
 ]
 
@@ -3226,7 +3223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -3235,29 +3232,29 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -3269,7 +3266,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -3280,7 +3277,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap 1.9.3",
  "ryu",
- "serde 1.0.196",
+ "serde 1.0.197",
  "yaml-rust",
 ]
 
@@ -3424,6 +3421,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/eigerco/bcs.git)",
+ "blake2",
  "clap",
  "hex",
  "jsonrpsee",
@@ -3437,7 +3435,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-support",
  "move-vm-test-utils",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "tokio",
  "url",
@@ -3445,12 +3443,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3502,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3546,9 +3544,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3572,7 +3570,7 @@ dependencies = [
  "pest_derive",
  "rand",
  "regex",
- "serde 1.0.196",
+ "serde 1.0.197",
  "serde_json",
  "slug",
  "unic-segment",
@@ -3589,28 +3587,28 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3646,7 +3644,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 0.8.10",
+ "mio 0.8.11",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
@@ -3664,7 +3662,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3707,7 +3705,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -3725,7 +3723,7 @@ dependencies = [
  "combine",
  "indexmap 1.9.3",
  "itertools",
- "serde 1.0.196",
+ "serde 1.0.197",
 ]
 
 [[package]]
@@ -3734,7 +3732,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -3745,7 +3743,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -3797,7 +3795,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3922,18 +3920,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -3982,9 +3980,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -4006,10 +4004,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.91"
+name = "wasite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4017,24 +4021,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4044,9 +4048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4054,28 +4058,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4083,11 +4087,12 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall 0.4.1",
+ "wasite",
  "web-sys",
 ]
 
@@ -4134,7 +4139,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -4152,7 +4157,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -4172,17 +4177,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -4193,9 +4198,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4205,9 +4210,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4217,9 +4222,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4229,9 +4234,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4241,9 +4246,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4253,9 +4258,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4265,15 +4270,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
@@ -4323,7 +4328,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4343,5 +4348,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0"
 jsonrpsee = { version = "0.21", features = [ "http-client"] }
 tokio = { version = "1.36", features = ["rt", "time", "net"] }
 anyhow = "1.0"
+blake2 = "0.10"
 # Keep the version aligned with the clap version in the upstream repo https://github.com/move-language/move
 clap = { version = "3.2", features = ["derive"] }
 url = "2.5"

--- a/src/cmd/call_hash.rs
+++ b/src/cmd/call_hash.rs
@@ -1,0 +1,32 @@
+use crate::cmd::{read_bytes, script_args::args::HexEncodedBytes};
+
+use anyhow::Result;
+use blake2::{Blake2s256, Digest};
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Calculates the script transaction hash value.
+#[derive(Parser, Debug)]
+#[clap(about = "Generate call hash for script transaction")]
+pub struct CallHash {
+    /// Path to script transaction file (*.mvt) for a script execution.
+    #[clap(short, long)]
+    script_transaction_path: PathBuf,
+}
+
+impl CallHash {
+    /// Executes the command.
+    pub fn execute(&self) -> Result<()> {
+        let script_tx = read_bytes(&self.script_transaction_path)?;
+
+        let mut hasher = Blake2s256::new();
+        hasher.update(&script_tx[..]);
+        let call_hash: [u8; 32] = hasher.finalize().into();
+
+        let call_hash_hex = HexEncodedBytes::from(call_hash);
+
+        println!("Call hash: {call_hash_hex}");
+
+        Ok(())
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,6 +1,17 @@
 //! List of smove subcommands.
 
 pub(super) mod bundle;
+pub(super) mod call_hash;
 pub(super) mod node;
 pub(super) mod script;
 pub(super) mod script_args;
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Reads bytes from a file for the given path.
+pub(crate) fn read_bytes(file_path: &Path) -> Result<Vec<u8>> {
+    std::fs::read(file_path)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("Failure to read filename {}", file_path.display()))
+}

--- a/src/cmd/node/mod.rs
+++ b/src/cmd/node/mod.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use url::Url;
 
-mod rpc;
+pub(crate) mod rpc;
 
 /// Commands for accessing the node.
 #[derive(Parser)]

--- a/src/cmd/node/rpc/estimate_gas_execute.rs
+++ b/src/cmd/node/rpc/estimate_gas_execute.rs
@@ -1,4 +1,4 @@
-use super::{read_bytes, Estimation};
+use crate::cmd::{node::rpc::Estimation, read_bytes};
 use anyhow::{Context, Result};
 use clap::Parser;
 use jsonrpsee::core::client::ClientT;

--- a/src/cmd/node/rpc/estimate_gas_publish.rs
+++ b/src/cmd/node/rpc/estimate_gas_publish.rs
@@ -1,4 +1,4 @@
-use super::{read_bytes, Estimation};
+use crate::cmd::{node::rpc::Estimation, read_bytes};
 use anyhow::{Context, Result};
 use clap::Parser;
 use jsonrpsee::core::client::ClientT;

--- a/src/cmd/node/rpc/mod.rs
+++ b/src/cmd/node/rpc/mod.rs
@@ -5,18 +5,9 @@ pub(super) mod estimate_gas_publish;
 pub(super) mod gas_to_weight;
 pub(super) mod get_module_abi;
 
-use anyhow::{Context, Result};
 use move_core_types::vm_status::StatusCode;
 use serde::Deserialize;
 use std::fmt;
-use std::path::Path;
-
-/// Reads bytes from a file for the given path.
-fn read_bytes(file_path: &Path) -> Result<Vec<u8>> {
-    std::fs::read(file_path)
-        .map_err(anyhow::Error::from)
-        .with_context(|| format!("Failure to read filename {}", file_path.display()))
-}
 
 /// Gas estimation information.
 #[derive(Deserialize)]

--- a/src/cmd/script_args/args.rs
+++ b/src/cmd/script_args/args.rs
@@ -254,7 +254,7 @@ impl FromStr for FunctionArgType {
 
 /// Hex encoded bytes to allow for having bytes represented in JSON.
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct HexEncodedBytes(Vec<u8>);
+pub(crate) struct HexEncodedBytes(Vec<u8>);
 
 impl FromStr for HexEncodedBytes {
     type Err = Error;
@@ -268,6 +268,12 @@ impl FromStr for HexEncodedBytes {
         Ok(Self(hex::decode(hex_str).map_err(|e| {
             format_err!("decode hex-encoded string({s:?}) failed, caused by error: {e}",)
         })?))
+    }
+}
+
+impl From<[u8; 32]> for HexEncodedBytes {
+    fn from(arr: [u8; 32]) -> Self {
+        HexEncodedBytes(arr.to_vec())
     }
 }
 

--- a/src/cmd/script_args/mod.rs
+++ b/src/cmd/script_args/mod.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use move_core_types::language_storage::TypeTag;
 use type_args::TypeArgVec;
 
-mod args;
+pub(crate) mod args;
 mod type_args;
 
 /// Arguments for script functions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,13 @@ enum SmoveCommand {
         cmd: cmd::bundle::Bundle,
     },
 
+    /// Generate call hash for a script transaction.
+    #[clap(about = "Generate call hash for a script transaction")]
+    CallHash {
+        #[clap(flatten)]
+        cmd: cmd::call_hash::CallHash,
+    },
+
     /// Create a script transaction.
     #[clap(about = "Create a script transaction")]
     CreateTransaction {
@@ -67,5 +74,6 @@ pub fn smove_cli(cwd: PathBuf) -> Result<()> {
         SmoveCommand::Bundle { mut cmd } => cmd.execute(&ctx),
         SmoveCommand::Node { mut cmd } => cmd.execute(),
         SmoveCommand::CreateTransaction { mut cmd } => cmd.execute(&ctx),
+        SmoveCommand::CallHash { cmd } => cmd.execute(),
     }
 }


### PR DESCRIPTION
- To check pallet-move's storage for stored `Multisigs` in its `MultisigStorage`, we need the script transaction hash value
- Added a sub-command to calculate the call hash by a given script transaction